### PR TITLE
Corregimiento del apartado de Accesibilidades para un negocio

### DIFF
--- a/frontend/src/pages/registro/registro.css
+++ b/frontend/src/pages/registro/registro.css
@@ -25,9 +25,14 @@ body:has(.registro-fondo) #root {
   box-shadow: 0 8px 25px var(--color-shadow);
   width: 100%;
   max-width: 450px;
-  transition: transform 0.3s ease, box-shadow 0.3s ease, background-color 0.3s ease;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, background-color 0.3s ease, max-width 0.4s ease;
   animation: fadeIn 0.5s ease;
   margin: 0 auto;
+}
+
+/* Expandir formulario cuando hay grid de accesibilidades */
+.registro-form:has(.accesibilidad-grid) {
+  max-width: 800px;
 }
 
 .registro-form:hover {
@@ -238,6 +243,8 @@ select:hover {
   grid-template-columns: repeat(3, 1fr);
   gap: 0.8rem;
   margin-top: 0.5rem;
+  margin-bottom: 1.5rem;
+  width: 100%;
 }
 
 /* cada botón accesible */
@@ -247,11 +254,12 @@ select:hover {
   justify-content: space-between;
   background-color: var(--color-surface);
   border-radius: 10px;
-  padding: 0.8rem 1rem;
+  padding: 0.75rem 0.85rem;
   cursor: pointer;
   transition: all 0.2s ease-in-out;
   border: 2px solid transparent;
   box-shadow: 0 2px 6px var(--color-shadow);
+  min-height: 50px;
 }
 
 .accesibilidad-boton:hover {
@@ -267,9 +275,11 @@ select:hover {
 
 /* nombre */
 .accesibilidad-nombre {
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   font-weight: 500;
   color: var(--color-text);
+  flex: 1;
+  margin-right: 0.5rem;
 }
 
 /* tooltip */
@@ -437,6 +447,50 @@ select:hover {
 .location-text {
   font-size: 12px;
   color: #065f46;
+}
+
+/* === MEDIA QUERIES ADICIONALES === */
+@media (max-width: 850px) {
+  /* Ajustar el formulario expandido en tablets */
+  .registro-form:has(.accesibilidad-grid) {
+    max-width: 600px;
+  }
+}
+
+@media (max-width: 768px) {
+  .registro-form {
+    padding: 2.5rem 2rem;
+  }
+  
+  .registro-form:has(.accesibilidad-grid) {
+    max-width: 95%;
+  }
+}
+
+@media (max-width: 480px) {
+  .registro-form {
+    padding: 2rem 1.5rem;
+  }
+  
+  .registro-titulo {
+    font-size: 1.5rem;
+  }
+}
+
+/* Texto de login al final del formulario */
+.registro-login-text {
+  text-align: center;
+  margin-top: 1.5rem;
+  font-size: 0.95rem;
+}
+
+.registro-login-link {
+  text-decoration: none;
+  transition: opacity 0.2s ease;
+}
+
+.registro-login-link:hover {
+  text-decoration: underline;
 }
 
 @keyframes fadeIn {


### PR DESCRIPTION
### Descripcion 
Se corrigió la visualización de la lista de accesibilidades en el formulario de registro de negocio, que aparecía en una sola columna debido a que el contenedor del formulario tenía un ancho máximo de 450px. Se implementó una expansión dinámica del formulario a 800px cuando contiene el grid de accesibilidades usando :has(.accesibilidad-grid), se optimizaron los tamaños de fuente y padding de los botones de accesibilidad, se agregaron media queries para responsive en tablets y móviles, y se centró el texto "¿Ya tienes una cuenta? Inicia sesión" al final del formulario. Archivos modificados: registro.css.
### Fixes #152 

### image
<img width="1599" height="761" alt="image" src="https://github.com/user-attachments/assets/77d4e60d-7293-468a-bbb0-f71ba69bfaa9" />
