### PR TITLE
Correccion advertencia para subir logo de negocio

### DIFF
--- a/frontend/src/Components/Navbar.css
+++ b/frontend/src/Components/Navbar.css
@@ -360,6 +360,7 @@ body.dark-mode .logout:hover {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 12px;
   padding: 0 16px;
   box-shadow: 0 2px 8px rgba(255, 112, 67, 0.25);
   cursor: pointer;
@@ -369,7 +370,6 @@ body.dark-mode .logout:hover {
   left: 0;
   right: 0;
   animation: slideIn 0.3s ease-out;
-  z-index: 99;
 }
 
 @keyframes slideIn {
@@ -392,6 +392,7 @@ body.dark-mode .logout:hover {
   align-items: center;
   font-size: 20px;
   flex-shrink: 0;
+  margin-right: 12px;
   animation: pulse 2s infinite;
 }
 

--- a/frontend/src/Components/Navbar.tsx
+++ b/frontend/src/Components/Navbar.tsx
@@ -253,7 +253,7 @@ export default function Navbar() {
         >
           <div className="notification-badge"><i className="fas fa-exclamation-circle"></i></div>
           <div className="notification-message">
-            <span className="notification-title">Completa tu perfil</span>
+            <span className="notification-title">Completa tu perfil: </span>
             <span className="notification-detail">
               {missingItems.includes("logo") && missingItems.includes("verificación")
                 ? "Sube el logo de tu empresa"


### PR DESCRIPTION
## Descripcion

Se ajustó la barra de notificación para propietarios que no han subido el logo del negocio, aumentando el espacio entre el ícono y el texto para que no se superpongan.

## Fixez #177 

## Foto
<img width="516" height="121" alt="Screenshot_1" src="https://github.com/user-attachments/assets/a59dfd2f-1863-4edf-a2ba-cb1a5898b48e" />
