### PR TITLE
Galeria de imagenes

### DIFF
--- a/backend/src/business/business.module.ts
+++ b/backend/src/business/business.module.ts
@@ -7,6 +7,7 @@ import { AuthModule } from '../auth/auth.module';
 import { CloudinaryModule } from '../cloudinary/cloudinary.module';
 import { MapsModule } from '../maps/maps.module';
 import { BusinessEntity } from './entity/business.entity';
+import { BusinessImageEntity } from './entity/business-image.entity';
 import { UserEntity } from '../user/entity/user.entity';
 import { UserRolesEntity } from '../user_rol/entity/user_rol.entity';
 import { RolEntity } from '../roles/entity/rol.entity';
@@ -17,6 +18,7 @@ import { BusinessCategoryEntity } from 'src/business_category/entity/business_ca
   imports: [
     TypeOrmModule.forFeature([
       BusinessEntity,
+      BusinessImageEntity,
       UserEntity,
       UserRolesEntity,
       RolEntity,

--- a/backend/src/business/business.public.controller.ts
+++ b/backend/src/business/business.public.controller.ts
@@ -88,6 +88,12 @@ export class BusinessPublicController {
       longitude: b.longitude,
       coordinates: b.coordinates,
       verified: b.verified || false,
+      images: Array.isArray(b.images)
+        ? b.images.map((img: any) => ({
+            id: img.id,
+            url: img.url,
+          }))
+        : [],
       business_accessibility: Array.isArray(b.business_accessibility)
         ? b.business_accessibility.map((ba: any) => ({
             accessibility_id: ba.accessibility?.accessibility_id,
@@ -116,7 +122,7 @@ export class BusinessPublicController {
     const businessAccessibilities =
       await this.businessAccessibilityRepository.find({
         where: { accessibility: { accessibility_id: accessibilityIdNum } },
-        relations: ['business', 'business.user', 'business.user.people'],
+        relations: ['business', 'business.user', 'business.user.people', 'business.images'],
       });
 
     // Mapear a formato público
@@ -138,6 +144,12 @@ export class BusinessPublicController {
         owner_name: b.user?.people
           ? `${b.user.people.firstName || ''} ${b.user.people.firstLastName || ''}`.trim()
           : null,
+        images: Array.isArray(b.images)
+          ? b.images.map((img: any) => ({
+              id: img.id,
+              url: img.url,
+            }))
+          : [],
       };
     });
   }
@@ -165,6 +177,12 @@ export class BusinessPublicController {
       owner_name: b.user?.people
         ? `${b.user.people.firstName || ''} ${b.user.people.firstLastName || ''}`.trim()
         : null,
+      images: Array.isArray(b.images)
+        ? b.images.map((img: any) => ({
+            id: img.id,
+            url: img.url,
+          }))
+        : [],
       business_accessibility: Array.isArray(b.business_accessibility)
         ? b.business_accessibility.map((ba: any) => ({
             id: ba.id ?? ba.business_accessibility_id,

--- a/backend/src/business/entity/business-image.entity.ts
+++ b/backend/src/business/entity/business-image.entity.ts
@@ -1,0 +1,20 @@
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { BusinessEntity } from './business.entity';
+
+@Entity({ name: 'business_images' })
+export class BusinessImageEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'varchar', length: 500 })
+  url: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  public_id: string | null;
+
+  @ManyToOne(() => BusinessEntity, (business) => business.images, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'business_id' })
+  business: BusinessEntity;
+}

--- a/backend/src/business/entity/business.entity.ts
+++ b/backend/src/business/entity/business.entity.ts
@@ -2,6 +2,7 @@ import { BusinessAccessibilityEntity } from 'src/business_accessibility/entity/b
 import { BusinessCategoryEntity } from 'src/business_category/entity/business_category.entity';
 import { ReviewEntity } from 'src/review/entity/review.entity';
 import { UserEntity } from 'src/user/entity/user.entity';
+import { BusinessImageEntity } from './business-image.entity';
 import {
   Column,
   Entity,
@@ -95,4 +96,9 @@ export class BusinessEntity {
     { cascade: true },
   )
   business_categories: BusinessCategoryEntity[];
+
+  @OneToMany(() => BusinessImageEntity, (image) => image.business, {
+    cascade: true,
+  })
+  images: BusinessImageEntity[];
 }

--- a/frontend/src/Components/OwnerBusinessProfile/OwnerBusinessProfile.css
+++ b/frontend/src/Components/OwnerBusinessProfile/OwnerBusinessProfile.css
@@ -265,6 +265,265 @@ body.dark-mode .no-categories {
   color: rgba(156, 163, 175, 0.8);
 }
 
+.business-gallery {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 8px 0;
+}
+
+.business-gallery-wrapper-read {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  position: relative;
+  min-height: 110px; /* espacio base para las 2 miniaturas */
+}
+
+/* En vista de lectura, mostrar siempre las imágenes en 2 columnas */
+.business-gallery-wrapper-read .business-gallery {
+  display: grid;
+  grid-template-columns: repeat(2, 90px); /* 2 columnas del mismo ancho que la miniatura */
+  justify-content: center;                 /* centradas bajo el logo */
+  gap: 10px;
+  padding: 8px 0;
+}
+
+.business-gallery-wrapper-read.expanded {
+  overflow: visible;
+}
+
+.business-gallery-wrapper-read.expanded .business-gallery {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 5;
+  padding: 8px 4px 10px;
+  background: var(--color-card-bg);
+  border-radius: 8px;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.18);
+}
+
+.business-gallery-image {
+  width: 90px;
+  height: 90px;
+  border-radius: 8px;
+  object-fit: cover;
+  border: 1px solid var(--color-border);
+}
+
+.business-gallery.edit-mode {
+  margin-top: 10px;
+  max-height: 140px;
+  overflow-y: auto;     
+}
+
+.business-gallery-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.gallery-more-btn {
+  border: none;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  cursor: pointer;
+  background: linear-gradient(135deg, #e5e7eb, #d1d5db);
+  color: #374151;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  transition: background 0.25s ease, transform 0.2s ease, color 0.2s ease, box-shadow 0.25s ease;
+}
+
+.gallery-more-btn::after {
+  content: "▾";
+  font-size: 11px;
+  transition: transform 0.2s ease;
+}
+
+.business-gallery-wrapper-read.expanded .gallery-more-btn {
+  position: relative;
+  z-index: 6; /* por encima del panel de imágenes */
+  background: linear-gradient(135deg, #10b981, #059669);
+  color: #ffffff;
+  box-shadow: 0 4px 10px rgba(16, 185, 129, 0.35);
+}
+
+.business-gallery-wrapper-read.expanded .gallery-more-btn::after {
+  transform: rotate(180deg); /* flecha hacia arriba en "Ver menos" */
+}
+
+.gallery-more-btn:hover {
+  background: linear-gradient(135deg, #d1d5db, #e5e7eb);
+  transform: translateY(-1px);
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.12);
+}
+
+body.dark-mode .gallery-more-btn {
+  background: linear-gradient(135deg, #111827, #1f2933);
+  color: #e5e7eb;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.6);
+}
+
+body.dark-mode .gallery-more-btn:hover {
+  background: linear-gradient(135deg, #1f2937, #111827);
+}
+
+.gallery-delete-btn {
+  border: none;
+  padding: 4px 8px;
+  border-radius: 6px;
+  font-size: 12px;
+  cursor: pointer;
+  background: #f97373;
+  color: #ffffff;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.gallery-delete-btn:hover {
+  background: #ef4444;
+  transform: translateY(-1px);
+}
+
+body.dark-mode .gallery-delete-btn {
+  background: #b91c1c;
+  color: #fee2e2;
+  border: 1px solid #fecaca;
+}
+
+body.dark-mode .gallery-delete-btn:hover {
+  background: #dc2626;
+  transform: translateY(-1px);
+}
+
+.uploading-text {
+  font-size: 13px;
+  color: var(--color-text-muted);
+  margin-top: 6px;
+}
+
+.gallery-upload-control {
+  display: flex;
+  align-items: center;
+}
+
+.gallery-upload-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 300px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #22c55e, #16a34a);
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  box-shadow: 0 3px 8px rgba(22, 163, 74, 0.4);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.gallery-upload-btn i {
+  font-size: 14px;
+}
+
+.gallery-upload-btn.uploading {
+  position: relative;
+  pointer-events: none;
+  opacity: 0.95;
+  background: linear-gradient(90deg, #16a34a, #22c55e, #16a34a);
+  background-size: 200% 100%;
+  animation: gallery-upload-bg 1.1s linear infinite;
+}
+
+.gallery-upload-btn.uploading i {
+  animation: gallery-upload-spin 0.9s linear infinite;
+}
+
+.gallery-upload-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(22, 163, 74, 0.55);
+}
+
+.gallery-upload-btn:active {
+  transform: translateY(0);
+  box-shadow: 0 2px 6px rgba(37, 99, 235, 0.35);
+}
+
+@keyframes gallery-upload-bg {
+  0% {
+    background-position: 0% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+@keyframes gallery-upload-spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.image-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+
+.image-modal-content {
+  position: relative;
+  max-width: 90vw;
+  max-height: 90vh;
+  background: #111827;
+  border-radius: 12px;
+  padding: 12px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.6);
+}
+
+.image-modal-content img {
+  display: block;
+  max-width: 80vw;
+  max-height: 80vh;
+  border-radius: 10px;
+}
+
+.image-modal-close {
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  border: none;
+  background: rgba(15, 23, 42, 0.8);
+  color: #e5e7eb;
+  border-radius: 999px;
+  width: 28px;
+  height: 28px;
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.image-modal-close:hover {
+  background: rgba(31, 41, 55, 0.95);
+}
+
 .profile-actions {
   display: flex;
   gap: 12px;

--- a/frontend/src/pages/local/LocalDetalle.css
+++ b/frontend/src/pages/local/LocalDetalle.css
@@ -469,8 +469,77 @@
   box-shadow: var(--shadow-md);
 }
 
+.galeria-card {
+  margin-top: 1.5rem;
+}
 
+.galeria-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+  gap: 10px;
+}
 
+.galeria-imagen {
+  width: 100%;
+  max-width: 110px;
+  height: 80px;
+  border-radius: 10px;
+  object-fit: cover;
+  border: 1px solid var(--color-border);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.18);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
 
+.galeria-imagen:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.25);
+}
 
+.local-image-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
 
+.local-image-modal-content {
+  position: relative;
+  max-width: 90vw;
+  max-height: 90vh;
+  background: #111827;
+  border-radius: 12px;
+  padding: 12px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.6);
+}
+
+.local-image-modal-content img {
+  display: block;
+  max-width: 80vw;
+  max-height: 80vh;
+  border-radius: 10px;
+}
+
+.local-image-modal-close {
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  border: none;
+  background: rgba(15, 23, 42, 0.8);
+  color: #e5e7eb;
+  border-radius: 999px;
+  width: 28px;
+  height: 28px;
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.local-image-modal-close:hover {
+  background: rgba(31, 41, 55, 0.95);
+}

--- a/frontend/src/pages/local/LocalDetalle.tsx
+++ b/frontend/src/pages/local/LocalDetalle.tsx
@@ -71,6 +71,7 @@ interface LocalData {
   longitude?: number | null;
   business_accessibility?: BusinessAccessibilityItem[];
   business_categories?: { category_id: number; category_name: string }[];
+  images?: { id: number; url: string }[];
 }
 
 /* Fallback accesibilidad */
@@ -233,6 +234,7 @@ const LocalDetalle: React.FC = () => {
   const [editing, setEditing] = useState<any | null>(null);
   const [copied, setCopied] = useState(false);
   const [isFavorite, setIsFavorite] = useState(false);
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
 
   const { user } = useAuth();
   const token = localStorage.getItem("token");
@@ -408,6 +410,14 @@ const LocalDetalle: React.FC = () => {
       };
       localStorage.setItem(key, JSON.stringify(parsed));
     } catch {}
+  };
+
+  const handleOpenImage = (url: string) => {
+    setSelectedImage(url);
+  };
+
+  const handleCloseImage = () => {
+    setSelectedImage(null);
   };
 
   const applyNewAverageFromReviews = (reviewsArray: any[]) => {
@@ -682,6 +692,23 @@ const LocalDetalle: React.FC = () => {
                 <p>{data.description || "Sin descripción disponible"}</p>
               </div>
 
+              {Array.isArray(data.images) && data.images.length > 0 && (
+                <div className="card galeria-card">
+                  <h2>Galería</h2>
+                  <div className="galeria-grid">
+                    {data.images.map((img) => (
+                      <img
+                        key={img.id}
+                        src={img.url}
+                        alt={data.business_name}
+                        className="galeria-imagen"
+                        onClick={() => handleOpenImage(img.url)}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )}
+
               {/* Categorías */}
               {Array.isArray(data.business_categories) &&
                 data.business_categories.length > 0 && (
@@ -852,6 +879,23 @@ const LocalDetalle: React.FC = () => {
             )}
           </section>
         </>
+      )}
+      {selectedImage && (
+        <div className="local-image-modal-overlay" onClick={handleCloseImage}>
+          <div
+            className="local-image-modal-content"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <img src={selectedImage} alt={data?.business_name || "Imagen"} />
+            <button
+              type="button"
+              className="local-image-modal-close"
+              onClick={handleCloseImage}
+            >
+              ×
+            </button>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/services/businessImages.ts
+++ b/frontend/src/services/businessImages.ts
@@ -1,0 +1,71 @@
+import { API_URL } from '../config/api';
+
+export interface BusinessImageDto {
+  id: number;
+  url: string;
+}
+
+export interface UploadBusinessImagesResponse {
+  message: string;
+  images: BusinessImageDto[];
+}
+
+class BusinessImagesService {
+  private getAuthHeaders() {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      throw new Error('Token de autenticación no encontrado');
+    }
+    return {
+      Authorization: `Bearer ${token}`,
+    } as HeadersInit;
+  }
+
+  async uploadImages(
+    businessId: number,
+    files: File[],
+  ): Promise<UploadBusinessImagesResponse> {
+    const formData = new FormData();
+
+    files.forEach((file) => {
+      formData.append('images', file);
+    });
+
+    const response = await fetch(`${API_URL}/business/${businessId}/images`, {
+      method: 'POST',
+      headers: this.getAuthHeaders(),
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => null);
+      throw new Error(
+        errorData?.message ||
+          `Error al subir imágenes: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const result = await response.json();
+    return result as UploadBusinessImagesResponse;
+  }
+
+  async deleteImage(businessId: number, imageId: number): Promise<void> {
+    const response = await fetch(
+      `${API_URL}/business/${businessId}/images/${imageId}`,
+      {
+        method: 'DELETE',
+        headers: this.getAuthHeaders(),
+      },
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => '');
+      throw new Error(
+        errorText ||
+          `Error al eliminar imagen: ${response.status} ${response.statusText}`,
+      );
+    }
+  }
+}
+
+export const businessImagesService = new BusinessImagesService();


### PR DESCRIPTION
## Descripcion

Se implementó una galería de imágenes tanto en el perfil de propietario como en la página pública del local. En el perfil del propietario, las fotos se muestran debajo del logo como miniaturas organizadas, en modo edición, se pueden subir nuevas imágenes, eliminarlas. En la vista de solo lectura, debajo del logo solo se ven dos fotos y un botón “Ver más / Ver menos”: al pulsarlo se despliega un panel flotante con todas las imágenes.

En la página de detalle público del local se añadió una galería más compacta: las imágenes se muestran como miniaturas pequeñas.

## Fixez #200 

## Video

https://github.com/user-attachments/assets/3d22a49e-8055-4de2-bf8f-e522f469f98c

