### PR TITLE
Visualizacion de imagenes en el Dashboard

### DIFF
--- a/frontend/src/Components/OwnerBusinessProfile/OwnerBusinessProfile.tsx
+++ b/frontend/src/Components/OwnerBusinessProfile/OwnerBusinessProfile.tsx
@@ -66,7 +66,6 @@ export default function OwnerBusinessProfile() {
   const [isSaving, setIsSaving] = useState(false);
   const [isUploadingImages, setIsUploadingImages] = useState(false);
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
-  const [showAllGallery, setShowAllGallery] = useState(false);
   const [editData, setEditData] = useState<EditState>({
     business_name: "",
     business_address: "",
@@ -696,7 +695,10 @@ export default function OwnerBusinessProfile() {
           <div className="profile-view">
             <div className="logo-section">
               {businessData.logo_url ? (
-                <div className="logo-container">
+                <div
+                  className="logo-container"
+                  style={{ width: 200, height: 200 }}
+                >
                   <img src={businessData.logo_url} alt={businessData.business_name} className="business-logo" />
                   {businessData.verified && (
                     <div className="logo-verification-badge">
@@ -708,38 +710,6 @@ export default function OwnerBusinessProfile() {
                 <div className="no-logo">
                   <i className="fas fa-image"></i>
                   <p>Sin logo</p>
-                </div>
-              )}
-
-              {Array.isArray(businessData.images) && businessData.images.length > 0 && (
-                <div
-                  className={`business-gallery-wrapper-read ${
-                    showAllGallery ? "expanded" : ""
-                  }`}
-                >
-                  <div className="business-gallery">
-                    {(showAllGallery
-                      ? businessData.images
-                      : businessData.images.slice(0, 2)
-                    ).map((img) => (
-                      <img
-                        key={img.id}
-                        src={img.url}
-                        alt={businessData.business_name}
-                        className="business-gallery-image"
-                        onClick={() => handleOpenImage(img.url)}
-                      />
-                    ))}
-                  </div>
-                  {businessData.images.length > 2 && (
-                    <button
-                      type="button"
-                      className="gallery-more-btn"
-                      onClick={() => setShowAllGallery((prev) => !prev)}
-                    >
-                      {showAllGallery ? "Ver menos" : "Ver más"}
-                    </button>
-                  )}
                 </div>
               )}
             </div>

--- a/frontend/src/Components/OwnerDashboard/MetricsGrid.tsx
+++ b/frontend/src/Components/OwnerDashboard/MetricsGrid.tsx
@@ -4,9 +4,12 @@ import { BusinessStatistics } from "../../services/ownerStatistics";
 
 interface MetricsGridProps {
   statistics: BusinessStatistics;
+  businessImages?: { id: number; url: string }[];
+  businessName?: string | null;
+  onImageClick?: (url: string) => void;
 }
 
-export default function MetricsGrid({ statistics }: MetricsGridProps) {
+export default function MetricsGrid({ statistics, businessImages = [], businessName, onImageClick }: MetricsGridProps) {
   const [animatedViews, setAnimatedViews] = useState(0);
   const [animatedRating, setAnimatedRating] = useState(0);
   const [animatedReviews, setAnimatedReviews] = useState(0);

--- a/frontend/src/Components/OwnerDashboard/OwnerDashboard.css
+++ b/frontend/src/Components/OwnerDashboard/OwnerDashboard.css
@@ -233,6 +233,82 @@
   font-weight: 500;
 }
 
+.metric-photos-thumbs {
+  margin-top: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.metric-photo-thumb {
+  width: 50px;
+  height: 50px;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  background-color: var(--color-surface);
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.metric-photo-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.metric-photo-more {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+/* Modal de imagen ampliada */
+.image-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+
+.image-modal-content {
+  position: relative;
+  max-width: 90vw;
+  max-height: 90vh;
+  background: #fff;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3);
+}
+
+.image-modal-content img {
+  display: block;
+  max-width: 100%;
+  max-height: 90vh;
+  object-fit: contain;
+}
+
+.image-modal-close {
+  position: absolute;
+  top: 0.4rem;
+  right: 0.6rem;
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  width: 28px;
+  height: 28px;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .trend-up {
   color: var(--color-positive);
 }
@@ -296,6 +372,10 @@
   transition: all 0.3s ease;
 }
 
+.owner-photos-card {
+  padding-bottom: 1.25rem;
+}
+
 .card-header {
   display: flex;
   align-items: center;
@@ -324,6 +404,30 @@
 
 .view-all-btn:hover {
   background-color: rgba(59, 130, 246, 0.1);
+}
+
+.owner-photos-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, 50px);
+  gap: 0.5rem;
+  justify-content: flex-start;
+}
+
+.owner-photo-item {
+  border-radius: 0.75rem;
+  overflow: hidden;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  width: 70px;
+  height: 70px;
+}
+
+.owner-photo-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  cursor: pointer;
 }
 
 .empty-state {


### PR DESCRIPTION
## Descripcion

Se centralizó la visualización de las fotos del negocio en el dashboard del propietario: ahora, las imágenes que se suben desde el perfil ya no se muestran debajo del logo ahí, sino que aparecen organizadas en una galería debajo de las reseñas recientes en el inicio del propietario.

## Fixez #216 

## Foto
<img width="1077" height="352" alt="Screenshot_5" src="https://github.com/user-attachments/assets/ef4e0d8b-cba8-40cf-bb6d-a4cb603e96a4" />
