### PR TITLE
Rediseño de reseñas recientes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,7 @@ import 'react-toastify/dist/ReactToastify.css';
 import Footer from "./Components/Footer";
 import LocalRecognitionPage from './pages/LocalRecognition/LocalRecognition';
 import ReviewsPage from "./pages/reviews/ReviewsPage";
+import OwnerBusinessReviewsPage from "./pages/reviews/OwnerBusinessReviewsPage";
 import SessionModal from "./Components/SessionModal/SessionModal";
 import { setSessionModalCallback } from "./config/api";
 import Accesibilidad from "./pages/accesibilidad/Accesibilidad";
@@ -99,6 +100,8 @@ function AppContent() {
 
           <Route element={<ProtectedRoute />}>
             <Route path="/perfil" element={<Perfil />} />
+            <Route path="/owner/reviews" element={<OwnerBusinessReviewsPage />} />
+            
             <Route path="/reconocimiento" element={<LocalRecognitionPage />} />
             
             <Route

--- a/frontend/src/Components/OwnerDashboard/OwnerDashboard.css
+++ b/frontend/src/Components/OwnerDashboard/OwnerDashboard.css
@@ -572,11 +572,11 @@
 .reviews-list {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .review-item {
-  padding: 1rem;
+  padding: 0.6rem;
   background-color: var(--color-surface);
   border-radius: 0.75rem;
   border: 1px solid var(--color-border);
@@ -586,18 +586,18 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.5rem;
 }
 
 .review-user {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.4rem;
   align-items: center;
 }
 
 .user-avatar {
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 1.6rem;
+  height: 1.6rem;
   border-radius: 50%;
   background: linear-gradient(135deg, var(--color-views), var(--color-reviews));
   color: white;
@@ -605,7 +605,7 @@
   align-items: center;
   justify-content: center;
   font-weight: 700;
-  font-size: 1rem;
+  font-size: 0.75rem;
 }
 
 .user-info {
@@ -616,11 +616,11 @@
 .user-name {
   font-weight: 600;
   color: var(--color-text);
-  font-size: 0.875rem;
+  font-size: 0.75rem;
 }
 
 .review-date {
-  font-size: 0.75rem;
+  font-size: 0.65rem;
   color: var(--color-text-muted);
 }
 

--- a/frontend/src/Components/OwnerDashboard/OwnerDashboard.tsx
+++ b/frontend/src/Components/OwnerDashboard/OwnerDashboard.tsx
@@ -169,7 +169,11 @@ export default function OwnerDashboard() {
           <RatingDistribution distribution={statistics.rating.distribution} />
           <VisitsChart views={statistics.views} />
           <SentimentAnalysis sentiment={statistics.reviews.sentiment} />
-          <RecentReviews reviews={statistics.recentReviews} businessId={businessId} />
+          <RecentReviews
+            reviews={statistics.recentReviews}
+            businessId={businessId}
+            limit={2}
+          />
 
           {businessImages.length > 0 && (
             <div className="dashboard-card owner-photos-card">

--- a/frontend/src/Components/OwnerDashboard/QuickActions.tsx
+++ b/frontend/src/Components/OwnerDashboard/QuickActions.tsx
@@ -28,7 +28,7 @@ export default function QuickActions({ businessId }: QuickActionsProps) {
       icon: <MessageCircle size={20} />,
       label: "Ver Reseñas",
       description: "Revisa los comentarios",
-      onClick: () => navigate(`/local/${businessId}`),
+      onClick: () => navigate("/owner/reviews"),
       color: "action-green",
     },
     {

--- a/frontend/src/Components/OwnerDashboard/RecentReviews.tsx
+++ b/frontend/src/Components/OwnerDashboard/RecentReviews.tsx
@@ -18,13 +18,17 @@ interface RecentReviewsProps {
     };
   }>;
   businessId: number;
+  limit?: number;
+  showViewAllButton?: boolean;
 }
 
-export default function RecentReviews({ reviews, businessId }: RecentReviewsProps) {
+export default function RecentReviews({ reviews, businessId, limit, showViewAllButton = true }: RecentReviewsProps) {
   const navigate = useNavigate();
   const [replyDrafts, setReplyDrafts] = useState<Record<number, string>>({});
   const [savingReplies, setSavingReplies] = useState<number[]>([]);
   const [editingReplyId, setEditingReplyId] = useState<number | null>(null);
+
+  const displayedReviews = (limit && limit > 0 ? reviews.slice(0, limit) : reviews) || [];
 
   useEffect(() => {
     const drafts: Record<number, string> = {};
@@ -124,7 +128,7 @@ export default function RecentReviews({ reviews, businessId }: RecentReviewsProp
     const d = new Date(date);
     const now = new Date();
     const diffTime = Math.abs(now.getTime() - d.getTime());
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+    const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
 
     if (diffDays === 0) return "Hoy";
     if (diffDays === 1) return "Ayer";
@@ -136,22 +140,24 @@ export default function RecentReviews({ reviews, businessId }: RecentReviewsProp
     <div className="dashboard-card recent-reviews">
       <div className="card-header">
         <h3 className="card-title">💬 Reseñas Recientes</h3>
-        <button
-          className="view-all-btn"
-          onClick={() => navigate(`/local/${businessId}`)}
-        >
-          Ver todas →
-        </button>
+        {showViewAllButton && reviews.length > 0 && (
+          <button
+            className="view-all-btn"
+            onClick={() => navigate("/owner/reviews")}
+          >
+            Ver todas →
+          </button>
+        )}
       </div>
 
-      {reviews.length === 0 ? (
+      {displayedReviews.length === 0 ? (
         <div className="empty-state">
           <p>No hay reseñas aún</p>
           <small>Las reseñas de tus clientes aparecerán aquí</small>
         </div>
       ) : (
         <div className="reviews-list">
-          {reviews.map((review) => (
+          {displayedReviews.map((review) => (
             <div key={review.review_id} className="review-item">
               <div className="review-header">
                 <div className="review-user">

--- a/frontend/src/pages/reviews/OwnerBusinessReviewsPage.tsx
+++ b/frontend/src/pages/reviews/OwnerBusinessReviewsPage.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../../context/AuthContext";
+import { api } from "../../config/api";
+import RecentReviews from "../../Components/OwnerDashboard/RecentReviews";
+import { getBusinessStatistics, BusinessStatistics } from "../../services/ownerStatistics";
+import "./reviews.css";
+
+export default function OwnerBusinessReviewsPage() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+
+  const [businessId, setBusinessId] = useState<number | null>(null);
+  const [businessName, setBusinessName] = useState<string | null>(null);
+  const [statistics, setStatistics] = useState<BusinessStatistics | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!user?.user_id) {
+        setError("No hay sesión activa");
+        setLoading(false);
+        return;
+      }
+
+      try {
+        setLoading(true);
+
+        // Obtener el negocio asociado al propietario
+        const businessResp = await api.get(`/user/${user.user_id}/business`);
+        const business = businessResp.data;
+
+        if (!business?.business_id) {
+          setError("No tienes un negocio asignado");
+          setLoading(false);
+          return;
+        }
+
+        setBusinessId(business.business_id);
+        setBusinessName(business.business_name || null);
+
+        // Reutilizar las estadísticas para obtener el listado de reseñas del negocio
+        const stats = await getBusinessStatistics(business.business_id);
+        setStatistics(stats);
+        setError(null);
+      } catch (err: any) {
+        setError(err?.response?.data?.message || "Error al cargar las reseñas");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    load();
+  }, [user?.user_id]);
+
+  if (loading) {
+    return (
+      <div style={{ maxWidth: 960, margin: "2rem auto", textAlign: "center" }}>
+        <p>Cargando reseñas...</p>
+      </div>
+    );
+  }
+
+  if (error || !businessId || !statistics) {
+    return (
+      <div style={{ maxWidth: 960, margin: "2rem auto", textAlign: "center" }}>
+        <button
+          type="button"
+          className="ownerBackBtn"
+          onClick={() => navigate(-1)}
+          style={{
+            marginBottom: "1rem",
+            padding: "0.5rem 1.1rem",
+            borderRadius: "999px",
+            border: "1px solid rgba(148,163,184,0.7)",
+            background: "#ffffff",
+            color: "#374151",
+            fontSize: "0.9rem",
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "0.3rem",
+            cursor: "pointer",
+            boxShadow: "0 6px 18px rgba(15,23,42,0.12)",
+          }}
+        >
+          ← Volver al panel
+        </button>
+        <p>{error || "No se pudieron cargar las reseñas"}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ maxWidth: 960, margin: "2rem auto" }}>
+      <button
+        type="button"
+        className="ownerBackBtn"
+        onClick={() => navigate(-1)}
+        style={{
+          marginBottom: "1rem",
+          padding: "0.5rem 1.1rem",
+          borderRadius: "999px",
+          border: "1px solid rgba(148,163,184,0.7)",
+          background: "#ffffff",
+          color: "#374151",
+          fontSize: "0.9rem",
+          display: "inline-flex",
+          alignItems: "center",
+          gap: "0.3rem",
+          cursor: "pointer",
+          boxShadow: "0 6px 18px rgba(15,23,42,0.12)",
+        }}
+      >
+        ← Volver
+      </button>
+
+      <h2 style={{ marginBottom: "1rem" }}>
+        Todas las reseñas de {businessName || "tu local"}
+      </h2>
+
+      {/* Mostrar todas las reseñas disponibles (sin límite) y sin botón "Ver todas" */}
+      <RecentReviews
+        reviews={statistics.recentReviews}
+        businessId={businessId}
+        showViewAllButton={false}
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/reviews/reviews.css
+++ b/frontend/src/pages/reviews/reviews.css
@@ -64,6 +64,36 @@ html.dark-mode {
   transform: translateY(-1px);
 }
 
+/* Botón volver para la vista de reseñas del propietario */
+.ownerBackBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 1rem;
+  padding: 8px 18px;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-card-bg);
+  color: var(--color-text);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 6px 18px var(--color-shadow);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.ownerBackBtn:hover {
+  background: var(--color-surface);
+  border-color: var(--color-primary);
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px var(--color-shadow-hover);
+}
+
+.ownerBackBtn:active {
+  transform: translateY(0);
+  box-shadow: 0 4px 12px var(--color-shadow);
+}
+
 .revTitle {
   font-size: 2.2rem;
   font-weight: 800;


### PR DESCRIPTION
## Descripcion

Se rediseñó la sección de reseñas del panel del propietario para que en el dashboard solo se muestren las 2 reseñas más recientes y, desde ahí, se pueda ir a una nueva página dedicada donde se ven en una lista todas las reseñas del negocio, Además, se ajustó el botón “Ver Reseñas” de Accesos Rápidos para que también lleve a esa página de todas las reseñas.

## Fixez #233 

## Video

https://github.com/user-attachments/assets/2507a6d4-c98d-46dc-97b2-cbe143f3617b

